### PR TITLE
Use context-receivers to reduced the number of parameters passed

### DIFF
--- a/app/src/main/kotlin/com/skydoves/orbitarydemo/MainActivity.kt
+++ b/app/src/main/kotlin/com/skydoves/orbitarydemo/MainActivity.kt
@@ -52,9 +52,9 @@ class MainActivity : ComponentActivity() {
     setContent {
       OrbitaryTheme {
         OrbiraySharedElementTransitionExample()
-//        OrbitarySharedElementTransitionExample()
-//        OrbitarTransformationExample()
-//        OrbitarMovementExample()
+        // OrbitaryMultipleSharedElementTransitionExample()
+        // OrbitarTransformationExample()
+        // OrbitarMovementExample()
       }
     }
   }
@@ -69,7 +69,7 @@ private fun OrbitarTransformationExample() {
         Modifier.size(300.dp, 620.dp)
       } else {
         Modifier.size(100.dp, 220.dp)
-      }.animateTransformation(this, transformationSpec),
+      }.animateTransformation(transformationSpec),
       imageModel = MockUtils.getMockPoster().poster,
       contentScale = ContentScale.Fit
     )
@@ -98,7 +98,7 @@ private fun OrbitarMovementExample() {
         Modifier.size(360.dp, 620.dp)
       } else {
         Modifier.size(130.dp, 220.dp)
-      }.animateMovement(this, movementSpec),
+      }.animateMovement(movementSpec),
       imageModel = ItemUtils.urls[3],
       contentScale = ContentScale.Fit
     )
@@ -141,7 +141,6 @@ private fun OrbiraySharedElementTransitionExample() {
       } else {
         Modifier.size(130.dp, 220.dp)
       }.animateSharedElementTransition(
-        this,
         SpringSpec(stiffness = 500f),
         SpringSpec(stiffness = 500f)
       ),
@@ -185,7 +184,7 @@ private fun OrbitaryMultipleSharedElementTransitionExample() {
         } else {
           Modifier.size(100.dp, 220.dp)
         }
-          .animateSharedElementTransition(this, movementSpec, transformationSpec)
+          .animateSharedElementTransition(movementSpec, transformationSpec)
           .padding(8.dp),
         imageModel = item.poster,
         contentScale = ContentScale.Fit

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,14 @@ buildscript {
   }
 }
 
+allprojects {
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+      freeCompilerArgs += "-Xcontext-receivers"
+    }
+  }
+}
+
 task clean(type: Delete) {
   delete rootProject.buildDir
 }

--- a/buildSrc/src/main/kotlin/com/skydoves/orbitary/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/skydoves/orbitary/Dependencies.kt
@@ -2,7 +2,7 @@ package com.skydoves.orbitary
 
 object Versions {
   internal const val ANDROID_GRADLE_PLUGIN = "7.2.0"
-  internal const val ANDROID_GRADLE_SPOTLESS = "6.3.0"
+  internal const val ANDROID_GRADLE_SPOTLESS = "6.7.0"
   internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "1.1.0"
   internal const val KOTLIN = "1.7.0"
   internal const val KOTLIN_GRADLE_DOKKA = "1.7.0"

--- a/orbitary/src/main/kotlin/com/skydoves/orbitary/AnimateSharedElementTransition.kt
+++ b/orbitary/src/main/kotlin/com/skydoves/orbitary/AnimateSharedElementTransition.kt
@@ -25,20 +25,19 @@ import androidx.compose.ui.unit.IntSize
  * Allows a custom modifier to animate the local position and size of the layout within the
  * LookaheadLayout, whenever there's a change in the layout.
  *
- * @param orbitaryScope The measurement and placement of any layout calculated in the lookahead pass can be observed via Modifier.
  * @param movementSpec An [AnimationSpec] which has [IntOffset] as a generic type.
  * @param transformSpec An [AnimationSpec] which has [IntSize] as a generic type.
  */
+context(OrbitaryScope)
 public fun Modifier.animateSharedElementTransition(
-  orbitaryScope: OrbitaryScope,
   movementSpec: AnimationSpec<IntOffset>,
   transformSpec: AnimationSpec<IntSize>,
 ): Modifier {
   return this
     .then(
-      animateMovement(orbitaryScope, movementSpec)
+      animateMovement(movementSpec)
     )
     .then(
-      animateTransformation(orbitaryScope, transformSpec)
+      animateTransformation(transformSpec)
     )
 }

--- a/spotless.gradle
+++ b/spotless.gradle
@@ -3,7 +3,7 @@ apply plugin: "com.diffplug.spotless"
 spotless {
   kotlin {
     target "**/*.kt"
-    ktlint().userData(['indent_size': '2', 'continuation_indent_size': '2'])
+    ktlint("0.45.2").editorConfigOverride(['indent_size': '2', 'continuation_indent_size': '2'])
     licenseHeaderFile '../spotless.license.kt'
     trimTrailingWhitespace()
     endWithNewline()


### PR DESCRIPTION
```kotlin
rememberContentWithOrbitaryScope {
  // Before
  Box(Modifier.animateXX(this, XXSpec)) { .. }
  // After
  Box(Modifier.animateXX(XXSpec)) { .. }
}
```

It will be easier to use.